### PR TITLE
fix(himalaya): #10 - fix --date-prefix flag parsing to match Himalaya's ISO 8601 format

### DIFF
--- a/himalaya-email-manager/scripts/email-save.py
+++ b/himalaya-email-manager/scripts/email-save.py
@@ -119,13 +119,19 @@ def generate_filename(
     }[output_format]
 
     if date_prefix:
-        try:
-            date_obj = datetime.strptime(date_str, "%a, %d %b %Y %H:%M:%S %z")
-            date_prefix_str = date_obj.strftime("%Y-%m-%d")
-            sanitized_subject = sanitize_filename(subject)
-            return f"{date_prefix_str}-{sanitized_subject}.{ext}"
-        except ValueError:
-            pass
+        for date_format in ["%Y-%m-%d %H:%M%z", "%Y-%m-%d %H:%M:%S%z"]:
+            try:
+                date_obj = datetime.strptime(date_str, date_format)
+                date_prefix_str = date_obj.strftime("%Y-%m-%d")
+                sanitized_subject = sanitize_filename(subject)
+                return f"{date_prefix_str}-{sanitized_subject}.{ext}"
+            except ValueError:
+                continue
+
+        console.print(
+            f"[yellow]⚠[/yellow] Could not parse date: [dim]{date_str}[/dim]\n"
+            f"[yellow]⚠[/yellow] Falling back to message ID in filename"
+        )
 
     return f"{message_id}.{ext}"
 


### PR DESCRIPTION
## Summary

Fixes the `--date-prefix` flag in `email-save.py` that was silently failing due to date format mismatch.

## Problem

The `--date-prefix` flag failed silently because:
- Code expected RFC 2822 format: `"Mon, 05 Jan 2026 08:00:00 +0000"`
- Himalaya returns ISO 8601 format: `"2026-01-05 08:00+00:00"`
- When parsing failed, the ValueError was caught silently and fell back to just `{message_id}.{ext}`

## Solution

Updated `generate_filename()` function to:
- Parse ISO 8601 format (Himalaya's actual format)
- Add fallback format for robustness
- Display warning message when date parsing fails instead of silent failure

## Testing

Tested with the example from issue #10:
```bash
nix-shell -p python3Packages.rich python3Packages.typer himalaya --run \
  "./himalaya-email-manager/scripts/email-save.py 56878 --date-prefix --format text --output /tmp/saved-emails"
```

**Before**: Filename was `56878.txt` (date prefix missing)  
**After**: Filename is `2026-01-05-Hoidettavia asioita.txt` (date prefix included ✓)

## Changes

- `himalaya-email-manager/scripts/email-save.py`: Updated `generate_filename()` to handle ISO 8601 date format

Closes #10